### PR TITLE
updates verifyEddsa example for ZoKrates 0.6.2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,17 @@ which should create a file called `zokrates_inputs.txt`.
 We can now create a small ZoKrates DSL file which wraps the existing `verifyEddsa` function in the standard library.
 
 ```
+from "ecc/babyjubjubParams" import BabyJubJubParams
 import "signatures/verifyEddsa.code" as verifyEddsa
 import "ecc/babyjubjubParams.code" as context
 
-def main(private field[2] R, private field S, field[2] A, field[256] M0, field[256] M1) -> (field):
+def main(private field[2] R, private field S, field[2] A, u32[8] M0, u32[8] M1) -> (bool):
 
-    context = context()
+	BabyJubJubParams context = context()
+	
+    bool isVerified = verifyEddsa(R, S, A, M0, M1, context)
 
-    field isVerified = verifyEddsa(R, S, A, M0, M1, context)
-
-    return isVerified
+	return isVerified
 ````
 
 After compiling this file we can now pass our input arguments into witness generation:

--- a/zokrates_pycrypto/utils.py
+++ b/zokrates_pycrypto/utils.py
@@ -35,8 +35,8 @@ def write_signature_for_zokrates_cli(pk, sig, msg, path):
 
     M0 = msg.hex()[:64]
     M1 = msg.hex()[64:]
-    b0 = BitArray(int(M0, 16).to_bytes(32, "big")).bin
-    b1 = BitArray(int(M1, 16).to_bytes(32, "big")).bin
+    b0 = [str(int(M0[i:i+8], 16)) for i in range(0,len(M0), 8)]
+    b1 = [str(int(M1[i:i+8], 16)) for i in range(0,len(M1), 8)]
     args = args + " " + " ".join(b0 + b1)
 
     with open(path, "w+") as file:


### PR DESCRIPTION
- the new verifyEddsa.zok uses `u32[8] ` as input format for M0, M1. Also, it now returns a `bool` -> Example in readme is updated to reflect that
- `utils.write_signature_for_zokrates_cli` now returns M0 and M1 as 8 byte integer instead of in binary format to be compatible with updated `verifyEddsa.zok`